### PR TITLE
Encode branch & extension nodes manually

### DIFF
--- a/assembly/debug.ts
+++ b/assembly/debug.ts
@@ -1,6 +1,10 @@
-export declare function debug(a: i32): void;
-export declare function debug_mem(pos: i32, len: i32): void;
+export declare function debug_print32(v: i32): void;
+export declare function debug_printMem(pos: i32, len: i32): void;
 
 export function debugMem(buf: Uint8Array): void {
-  debug_mem(buf.buffer as usize + buf.byteOffset, buf.length)
+  debug_printMem(buf.buffer as usize + buf.byteOffset, buf.length)
+}
+
+export function debug(v: i32): void {
+  debug_print32(v)
 }


### PR DESCRIPTION
`verifyMultiproof` was using `rlp.encode` to encode branch and extension nodes. However, `rlp.encode` is sort of inefficient. It can't predict the length of the whole buffer in advance and copies data a lot in memory. But branch and extension nodes have a known structure and a lot about them can be assumed (including total length of encoding), which results in much less memory allocations and copies. On wasmi this led to a 35% improve in performance.

@cdetrio had come up with this idea in his turbo-mpas project (his code is still there in `rlp.hashBranchNode` along with lots of helpful comments). I re-implemented because data structures I was using were a bit different.